### PR TITLE
Redirect on "Actually, nah"

### DIFF
--- a/extension/js/mindful.js
+++ b/extension/js/mindful.js
@@ -117,7 +117,7 @@
         "</div>",
         "<div class='options'>",
             "<a class='mindfulBtn' id='mindfulBrowsingContinue' href='#'>Yes, 10 minutes.</a>",
-            "<a class='mindfulBtn' id='mindfulBrowsingLeave' href='javascript:window.open(location,\"_self\");window.close();'>Actually, nah.</a>",
+            "<a class='mindfulBtn' id='mindfulBrowsingLeave' href='https://google.com'>Actually, nah.</a>",
         "</div>",
         "<a href='" + currentPhoto["credit_url"] + "' id='mindfulBrowsingPhotoCredit'>Photo by " + currentPhoto["credit"] + "</a>"
         ].join("");


### PR DESCRIPTION
The current js to close the tab does not work in chrome anymore. You could potentially redo how the overlay works and use extension api to close the tab, but it's a bit more than I can take on right now, so figured at least making it a redirect to google.com is a reasonable way to get away from where you were :)